### PR TITLE
Add support for 1.4 unit test output changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go-junit-report
+*.test

--- a/parser.go
+++ b/parser.go
@@ -34,7 +34,7 @@ type Test struct {
 }
 
 var (
-	regexStatus = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): (.+) \((-?\d+\.\d+) seconds\)$`)
+	regexStatus = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): (.+) \((-?\d+\.\d+)\s?[s|seconds]+\)$`)
 	regexResult = regexp.MustCompile(`^(ok|FAIL)\s+(.+)\s(-?\d+\.\d+)s$`)
 )
 

--- a/tests/01-pass.txt
+++ b/tests/01-pass.txt
@@ -1,5 +1,5 @@
 === RUN TestOne
---- PASS: TestOne (0.06 seconds)
+--- PASS: TestOne (0.06s)
 === RUN TestTwo
 --- PASS: TestTwo (0.10 seconds)
 PASS

--- a/tests/02-report.xml
+++ b/tests/02-report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite tests="3" failures="1" skips="1" time="0.151" name="package/name">
 	<properties>
-		<property name="go.version" value="go1.2.1"></property>
+		<property name="go.version" value="1.0"></property>
 	</properties>
 	<testcase classname="name" name="TestOne" time="0.020">
 		<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>


### PR DESCRIPTION
Go 1.4 changed the output from `(0.01 seconds)` to `(0.01s)`
This accounts for the change, and adds the ability for the regex
to support both.